### PR TITLE
Add 'opened' feature.

### DIFF
--- a/examples/activatable.rs
+++ b/examples/activatable.rs
@@ -1,11 +1,14 @@
-//! Demonstrates how to track nodes that were 'opened'.
-//! You can 'open' a node by either double-clicking or pressing enter on a node.
+//! Demonstrates how to 'activate' nodes by pressing enter on them
+//! or double clicking them. By default leaf nodes are activatable and
+//! directory nodes are not.
+//! You can configure if a node should be activatable by using the
+//! node builder.
 //! Works with multiple-selection too.
 //!
 #[path = "data.rs"]
 mod data;
 
-use egui::{Id, Modifiers, ThemePreference};
+use egui::{Id, ThemePreference};
 use egui_ltreeview::{Action, Activate, TreeView, TreeViewState};
 
 fn main() -> Result<(), eframe::Error> {
@@ -15,7 +18,7 @@ fn main() -> Result<(), eframe::Error> {
         ..Default::default()
     };
     eframe::run_native(
-        "Egui_ltreeview 'opened' node example",
+        "Egui_ltreeview 'activatable' example",
         options,
         Box::new(|cc| {
             cc.egui_ctx
@@ -27,14 +30,14 @@ fn main() -> Result<(), eframe::Error> {
 
 struct MyApp {
     tree: TreeViewState<i32>,
-    opened_history: Vec<(Vec<i32>, Modifiers)>,
+    activated_history: Vec<Vec<i32>>,
 }
 
 impl Default for MyApp {
     fn default() -> Self {
         Self {
             tree: TreeViewState::default(),
-            opened_history: Default::default(),
+            activated_history: Default::default(),
         }
     }
 }
@@ -65,16 +68,16 @@ impl eframe::App for MyApp {
                 match action {
                     Action::Activate(Activate {
                         selected,
-                        modifiers,
+                        modifiers: _,
                     }) => {
-                        self.opened_history.push((selected, modifiers));
+                        self.activated_history.push(selected);
                     }
                     _ => {}
                 }
             }
         });
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.label("Open selections by double-clicking or pressing enter.");
+            ui.label("Activate a selections by pressing enter or double-clicking.");
             ui.separator();
             ui.label("History");
 
@@ -84,21 +87,18 @@ impl eframe::App for MyApp {
                     ui.set_width(ui.available_width());
                     ui.set_min_height(200.0);
 
-                    if self.opened_history.is_empty() {
+                    if self.activated_history.is_empty() {
                         ui.label("Empty");
                     } else {
-                        for (selection, modifiers) in &self.opened_history {
-                            ui.label(format!(
-                                "selection: {:?}, modifiers: {:?}",
-                                selection, modifiers
-                            ));
+                        for selection in &self.activated_history {
+                            ui.label(format!("selection: {:?}", selection));
                         }
                     }
                 });
             });
 
             if ui.button("Clear history").clicked() {
-                self.opened_history.clear();
+                self.activated_history.clear();
             }
         });
     }

--- a/examples/opened.rs
+++ b/examples/opened.rs
@@ -6,7 +6,7 @@
 mod data;
 
 use egui::{Color32, Id, Modifiers, Stroke, ThemePreference};
-use egui_ltreeview::{TreeView, TreeViewState};
+use egui_ltreeview::{Action, Opened, TreeView, TreeViewState};
 
 fn main() -> Result<(), eframe::Error> {
     //env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -42,7 +42,7 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::SidePanel::left(Id::new("left")).show(ctx, |ui| {
-            TreeView::new(ui.make_persistent_id("Names tree view")).show_state(
+            let (_response, actions) = TreeView::new(ui.make_persistent_id("Names tree view")).show_state(
                 ui,
                 &mut self.tree,
                 |builder| {
@@ -63,6 +63,15 @@ impl eframe::App for MyApp {
                     builder.close_dir();
                 },
             );
+
+            for action in actions {
+                match action {
+                    Action::Opened(Opened { selected, modifiers }) => {
+                        self.opened_history.push((selected, modifiers));
+                    }
+                    _ => {}
+                }
+            }
         });
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.label("Open selections by double-clicking or pressing enter.");
@@ -89,9 +98,5 @@ impl eframe::App for MyApp {
                 self.opened_history.clear();
             }
         });
-
-        if let Some(node_id) = self.tree.opened() {
-            self.opened_history.push((self.tree.selected().clone(), node_id));
-        }
     }
 }

--- a/examples/opened.rs
+++ b/examples/opened.rs
@@ -5,7 +5,7 @@
 #[path = "data.rs"]
 mod data;
 
-use egui::{Color32, Id, Modifiers, Stroke, ThemePreference};
+use egui::{Id, Modifiers, ThemePreference};
 use egui_ltreeview::{Action, Opened, TreeView, TreeViewState};
 
 fn main() -> Result<(), eframe::Error> {

--- a/examples/opened.rs
+++ b/examples/opened.rs
@@ -6,7 +6,7 @@
 mod data;
 
 use egui::{Id, Modifiers, ThemePreference};
-use egui_ltreeview::{Action, Opened, TreeView, TreeViewState};
+use egui_ltreeview::{Action, Activate, TreeView, TreeViewState};
 
 fn main() -> Result<(), eframe::Error> {
     //env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -63,7 +63,7 @@ impl eframe::App for MyApp {
 
             for action in actions {
                 match action {
-                    Action::Opened(Opened {
+                    Action::Activate(Activate {
                         selected,
                         modifiers,
                     }) => {

--- a/examples/opened.rs
+++ b/examples/opened.rs
@@ -1,0 +1,97 @@
+//! Demonstrates how to track nodes that were 'opened'.
+//! You can 'open' a node by either double-clicking or pressing enter on a node.
+//! Works with multiple-selection too.
+//!
+#[path = "data.rs"]
+mod data;
+
+use egui::{Color32, Id, Modifiers, Stroke, ThemePreference};
+use egui_ltreeview::{TreeView, TreeViewState};
+
+fn main() -> Result<(), eframe::Error> {
+    //env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([640.0, 300.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Egui_ltreeview 'opened' node example",
+        options,
+        Box::new(|cc| {
+            cc.egui_ctx
+                .options_mut(|options| options.theme_preference = ThemePreference::Dark);
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}
+
+struct MyApp {
+    tree: TreeViewState<i32>,
+    opened_history: Vec<(Vec<i32>, Modifiers)>,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        Self {
+            tree: TreeViewState::default(),
+            opened_history: Default::default(),
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left(Id::new("left")).show(ctx, |ui| {
+            TreeView::new(ui.make_persistent_id("Names tree view")).show_state(
+                ui,
+                &mut self.tree,
+                |builder| {
+                    builder.dir(0, "Root");
+                    builder.dir(1, "Foo");
+                    builder.leaf(2, "Ava");
+                    builder.dir(3, "Bar");
+                    builder.leaf(4, "Benjamin");
+                    builder.leaf(5, "Charlotte");
+                    builder.close_dir();
+                    builder.close_dir();
+                    builder.leaf(6, "Daniel");
+                    builder.leaf(7, "Emma");
+                    builder.dir(8, "Baz");
+                    builder.leaf(9, "Finn");
+                    builder.leaf(10, "Grayson");
+                    builder.close_dir();
+                    builder.close_dir();
+                },
+            );
+        });
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label("Open selections by double-clicking or pressing enter.");
+            ui.separator();
+            ui.label("History");
+
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.set_max_width(ui.available_width());
+                egui::Frame::group(ui.style()).show(ui, |ui| {
+                    ui.set_width(ui.available_width());
+                    ui.set_min_height(200.0);
+
+                    if self.opened_history.is_empty() {
+                        ui.label("Empty");
+                    } else {
+                        for (selection, modifiers) in &self.opened_history {
+                            ui.label(format!("selection: {:?}, modifiers: {:?}", selection, modifiers));
+                        }
+                    }
+                });
+            });
+
+            if ui.button("Clear history").clicked() {
+                self.opened_history.clear();
+            }
+        });
+
+        if let Some(node_id) = self.tree.opened() {
+            self.opened_history.push((self.tree.selected().clone(), node_id));
+        }
+    }
+}

--- a/examples/opened.rs
+++ b/examples/opened.rs
@@ -42,10 +42,8 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::SidePanel::left(Id::new("left")).show(ctx, |ui| {
-            let (_response, actions) = TreeView::new(ui.make_persistent_id("Names tree view")).show_state(
-                ui,
-                &mut self.tree,
-                |builder| {
+            let (_response, actions) = TreeView::new(ui.make_persistent_id("Names tree view"))
+                .show_state(ui, &mut self.tree, |builder| {
                     builder.dir(0, "Root");
                     builder.dir(1, "Foo");
                     builder.leaf(2, "Ava");
@@ -61,12 +59,14 @@ impl eframe::App for MyApp {
                     builder.leaf(10, "Grayson");
                     builder.close_dir();
                     builder.close_dir();
-                },
-            );
+                });
 
             for action in actions {
                 match action {
-                    Action::Opened(Opened { selected, modifiers }) => {
+                    Action::Opened(Opened {
+                        selected,
+                        modifiers,
+                    }) => {
                         self.opened_history.push((selected, modifiers));
                     }
                     _ => {}
@@ -88,7 +88,10 @@ impl eframe::App for MyApp {
                         ui.label("Empty");
                     } else {
                         for (selection, modifiers) in &self.opened_history {
-                            ui.label(format!("selection: {:?}, modifiers: {:?}", selection, modifiers));
+                            ui.label(format!(
+                                "selection: {:?}, modifiers: {:?}",
+                                selection, modifiers
+                            ));
                         }
                     }
                 });

--- a/examples/playground/data.rs
+++ b/examples/playground/data.rs
@@ -17,11 +17,13 @@ pub struct Directory {
     pub children: Vec<Node>,
     pub custom_closer: bool,
     pub icon: bool,
+    pub activatable: bool,
 }
 pub struct File {
     pub id: Uuid,
     pub name: String,
     pub icon: bool,
+    pub activatable: bool,
 }
 
 impl Node {
@@ -32,6 +34,7 @@ impl Node {
             children,
             custom_closer: true,
             icon: false,
+            activatable: false,
         })
     }
 
@@ -40,6 +43,7 @@ impl Node {
             id: Uuid::new_v4(),
             name: String::from(name),
             icon: true,
+            activatable: true,
         })
     }
 
@@ -47,6 +51,13 @@ impl Node {
         match self {
             Node::Directory(dir) => &dir.id,
             Node::File(file) => &file.id,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Node::Directory(directory) => &directory.name,
+            Node::File(file) => &file.name,
         }
     }
 

--- a/examples/playground/main.rs
+++ b/examples/playground/main.rs
@@ -179,7 +179,7 @@ fn show_tree_view(ui: &mut Ui, app: &mut MyApp) -> Response {
             }
             Action::SetSelected(_) => {}
             Action::Drag(_dnd) => {}
-            Action::Opened(_) => {}
+            Action::Activate(_) => {}
         }
     }
     if app.settings.show_size {

--- a/examples/playground/main.rs
+++ b/examples/playground/main.rs
@@ -179,6 +179,7 @@ fn show_tree_view(ui: &mut Ui, app: &mut MyApp) -> Response {
             }
             Action::SetSelected(_) => {}
             Action::Drag(_dnd) => {}
+            Action::Opened(_) => {}
         }
     }
     if app.settings.show_size {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -177,6 +177,7 @@ impl<'ui, NodeIdType: NodeId> TreeViewBuilder<'ui, NodeIdType> {
             visible: self.parent_dir_is_open() && !node.flatten,
             drop_allowed: node.drop_allowed,
             dir: node.is_dir,
+            activatable: node.activatable,
         });
         self.result.row_rectangles.insert(
             node.id,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -246,15 +246,16 @@ impl<'ui, NodeIdType: NodeId> TreeViewBuilder<'ui, NodeIdType> {
         // that we should show a context menu one frame after the click has happened and the
         // context menu would never show up.
         // To fix this we handle the secondary click here and return the even in the result.
-        if self
+        let is_mouse_above_row = self
             .result
             .interaction
             .hover_pos()
-            .is_some_and(|pos| row.contains(pos))
+            .is_some_and(|pos| row.contains(pos));
+        if is_mouse_above_row
+            && self.result.interaction.secondary_clicked()
+            && !self.state.drag_valid()
         {
-            if self.result.interaction.secondary_clicked() && !self.state.drag_valid() {
-                self.result.seconday_click = Some(node.id);
-            }
+            self.result.seconday_click = Some(node.id);
         }
 
         // Show the context menu.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ impl<T> NodeId for T where
 pub struct TreeView<'context_menu, NodeIdType> {
     id: Id,
     settings: TreeViewSettings,
+    #[allow(clippy::type_complexity)]
     fallback_context_menu: Option<Box<dyn FnMut(&mut Ui, &Vec<NodeIdType>) + 'context_menu>>,
 }
 impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
@@ -417,7 +418,7 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
                             .node_state_of(node_id)
                             .is_some_and(|ns| ns.activatable)
                     })
-                    .map(|node_id| *node_id)
+                    .copied()
                     .collect::<Vec<_>>(),
                 modifiers: ui.ctx().input(|i| i.modifiers),
             }));
@@ -496,7 +497,7 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
     ) {
         // Transfer the secondary click
         if tree_view_result.seconday_click.is_some() {
-            state.secondary_selection = tree_view_result.seconday_click.clone();
+            state.secondary_selection = tree_view_result.seconday_click;
         }
 
         if !tree_view_result.context_menu_was_open {
@@ -905,7 +906,7 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
 }
 fn simplify_selection_for_dnd<NodeIdType: NodeId>(
     state: &TreeViewState<NodeIdType>,
-    nodes: &Vec<NodeIdType>,
+    nodes: &[NodeIdType],
 ) -> Vec<NodeIdType> {
     // When multiple nodes are selected it is possible that a folder is selected aswell as a
     // leaf inside that folder. In that case, a drag and drop action should only include the folder and not the leaf.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,7 +1068,7 @@ pub enum RowLayout {
 pub enum Action<NodeIdType> {
     /// Set the selected node to be this.
     SetSelected(Vec<NodeIdType>),
-    /// Move a node from one place to another.
+    /// Move set of nodes from one place to another.
     Move(DragAndDrop<NodeIdType>),
     /// An in-process drag and drop action where the node
     /// is currently dragged but not yet dropped.
@@ -1100,6 +1100,7 @@ impl<NodeIdType> DragAndDrop<NodeIdType> {
     }
 }
 
+/// Information about the opened action in the tree.
 #[derive(Clone)]
 pub struct Opened<NodeIdType> {
     /// The nodes that are being opened.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,7 +566,17 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
                         node_state.open = !node_state.open;
                     }
 
-                    //should_activate = true;
+                    if node_state.activatable {
+                        // This has the potential to clash with the previous action.
+                        // If a directory is activatable then double clicking it will toggle its
+                        // open state and activate the directory. Usually we would want one input
+                        // to have one effect but in this case it is impossible for us to know if the
+                        // user wants to activate the directory or toggle it.
+                        // We could add a configuration option to choose either toggle or activate
+                        // but in this case i think that doing both has the biggest chance to achieve
+                        // what the user wanted.
+                        should_activate = true;
+                    }
                 } else if interaction.clicked_by(egui::PointerButton::Primary) {
                     // must be handled after double-clicking to prevent the second click of the double-click
                     // performing 'click' actions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,16 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
 
         if input_result.should_activate {
             actions.push(Action::Activate(Activate {
-                selected: state.selected().clone(),
+                selected: state
+                    .selected()
+                    .iter()
+                    .filter(|node_id| {
+                        state
+                            .node_state_of(node_id)
+                            .is_some_and(|ns| ns.activatable)
+                    })
+                    .map(|node_id| *node_id)
+                    .collect::<Vec<_>>(),
                 modifiers: ui.ctx().input(|i| i.modifiers),
             }));
         }
@@ -553,7 +562,7 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
                     let node_state = state.node_state_of_mut(&node_id).unwrap();
                     node_state.open = !node_state.open;
 
-                    should_activate = true;
+                    //should_activate = true;
                 } else if interaction.clicked_by(egui::PointerButton::Primary) {
                     // must be handled after double-clicking to prevent the second click of the double-click
                     // performing 'click' actions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,7 +560,11 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
                 // was row double-clicked
                 if interaction.double_clicked() {
                     let node_state = state.node_state_of_mut(&node_id).unwrap();
-                    node_state.open = !node_state.open;
+                    // directories should only switch their opened state by double clicking if no modifiers
+                    // are pressed. If any modifier is pressed then the closer should be used.
+                    if node_state.dir && ui.ctx().input(|i| i.modifiers).is_none() {
+                        node_state.open = !node_state.open;
+                    }
 
                     //should_activate = true;
                 } else if interaction.clicked_by(egui::PointerButton::Primary) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
         }
 
         if let Some(modifiers) = input_result.opened {
-            actions.push(Action::Opened(Opened {
+            actions.push(Action::Activate(Activate {
                 selected: state.selected().clone(),
                 modifiers,
             }));
@@ -1073,8 +1073,12 @@ pub enum Action<NodeIdType> {
     /// An in-process drag and drop action where the node
     /// is currently dragged but not yet dropped.
     Drag(DragAndDrop<NodeIdType>),
-    /// Opened (by pressing enter on a selection or double clicking)
-    Opened(Opened<NodeIdType>),
+    /// Activate a set of nodes.
+    ///
+    /// When pressing enter or double clicking on a selection, the tree
+    /// view will create this action.
+    /// Can be used to open a file for example.
+    Activate(Activate<NodeIdType>),
 }
 
 /// Information about drag and drop action that is currently
@@ -1100,12 +1104,12 @@ impl<NodeIdType> DragAndDrop<NodeIdType> {
     }
 }
 
-/// Information about the opened action in the tree.
+/// Information about the `Activate` action in the tree.
 #[derive(Clone)]
-pub struct Opened<NodeIdType> {
-    /// The nodes that are being opened.
+pub struct Activate<NodeIdType> {
+    /// The nodes that are being activated.
     pub selected: Vec<NodeIdType>,
-    /// The modifiers that were active when the selection was opened.
+    /// The modifiers that were active when this action was generated.
     pub modifiers: Modifiers,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,10 @@ mod builder;
 mod node;
 mod state;
 
-use egui::{self, emath, epaint, layers::ShapeIdx, vec2, Event, EventFilter, Id, InnerResponse, Layout, Modifiers, NumExt, Rangef, Rect, Response, Sense, Shape, Stroke, Ui, Vec2};
+use egui::{
+    self, emath, epaint, layers::ShapeIdx, vec2, Event, EventFilter, Id, InnerResponse, Layout,
+    Modifiers, NumExt, Rangef, Rect, Response, Sense, Shape, Stroke, Ui, Vec2,
+};
 use std::{cmp::Ordering, collections::HashSet, hash::Hash};
 
 pub use builder::*;
@@ -405,7 +408,10 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
         }
 
         if let Some(modifiers) = input_result.opened {
-            actions.push(Action::Opened(Opened { selected: state.selected().clone(), modifiers }));
+            actions.push(Action::Opened(Opened {
+                selected: state.selected().clone(),
+                modifiers,
+            }));
         }
 
         // Reset the drag state.
@@ -651,7 +657,12 @@ impl<'context_menu, NodeIdType: NodeId> TreeView<'context_menu, NodeIdType> {
                             modifiers,
                             ..
                         } => {
-                            state.handle_key(key, modifiers, self.settings.allow_multi_select, &mut opened);
+                            state.handle_key(
+                                key,
+                                modifiers,
+                                self.settings.allow_multi_select,
+                                &mut opened,
+                            );
                             selection_changed = true;
                         }
                         _ => (),

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,9 +15,13 @@ pub struct NodeBuilder<'add_ui, NodeIdType> {
     pub(crate) drop_allowed: bool,
     pub(crate) activatable: bool,
     indent: usize,
+    #[allow(clippy::type_complexity)]
     icon: Option<Box<dyn FnMut(&mut Ui) + 'add_ui>>,
+    #[allow(clippy::type_complexity)]
     closer: Option<Box<dyn FnMut(&mut Ui, CloserState) + 'add_ui>>,
+    #[allow(clippy::type_complexity)]
     label: Option<Box<dyn FnMut(&mut Ui) + 'add_ui>>,
+    #[allow(clippy::type_complexity)]
     context_menu: Option<Box<dyn FnMut(&mut Ui) + 'add_ui>>,
 }
 impl<'add_ui, NodeIdType: NodeId> NodeBuilder<'add_ui, NodeIdType> {
@@ -288,8 +292,7 @@ impl<'add_ui, NodeIdType: NodeId> NodeBuilder<'add_ui, NodeIdType> {
                     ),
                 );
                 row
-            })
-            .inner;
+            });
     }
 
     pub(crate) fn show_context_menu(&mut self, response: &Response) -> bool {

--- a/src/node.rs
+++ b/src/node.rs
@@ -13,6 +13,7 @@ pub struct NodeBuilder<'add_ui, NodeIdType> {
     pub(crate) is_open: bool,
     pub(crate) default_open: bool,
     pub(crate) drop_allowed: bool,
+    pub(crate) activatable: bool,
     indent: usize,
     icon: Option<Box<dyn FnMut(&mut Ui) + 'add_ui>>,
     closer: Option<Box<dyn FnMut(&mut Ui, CloserState) + 'add_ui>>,
@@ -27,6 +28,7 @@ impl<'add_ui, NodeIdType: NodeId> NodeBuilder<'add_ui, NodeIdType> {
             is_dir: false,
             flatten: false,
             drop_allowed: false,
+            activatable: true,
             icon: None,
             closer: None,
             label: None,
@@ -44,6 +46,7 @@ impl<'add_ui, NodeIdType: NodeId> NodeBuilder<'add_ui, NodeIdType> {
             is_dir: true,
             flatten: false,
             drop_allowed: true,
+            activatable: false,
             icon: None,
             closer: None,
             label: None,
@@ -76,6 +79,12 @@ impl<'add_ui, NodeIdType: NodeId> NodeBuilder<'add_ui, NodeIdType> {
     /// Whether or not dropping onto this node is allowed.
     pub fn drop_allowed(mut self, drop_allowed: bool) -> Self {
         self.drop_allowed = drop_allowed;
+        self
+    }
+
+    /// Whether or not this node can be activated.
+    pub fn activatable(mut self, activatable: bool) -> Self {
+        self.activatable = activatable;
         self
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -97,7 +97,7 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
 
     /// Set which nodes are selected in the tree
     pub fn set_selected(&mut self, selected: Vec<NodeIdType>) {
-        self.selection_pivot = selected.first().map(|o| *o);
+        self.selection_pivot = selected.first().copied();
         self.selected = selected;
     }
 
@@ -118,15 +118,11 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
     /// Expand the node and all its parent nodes.
     /// Effectively this makes the node visible in the tree.
     pub fn expand_node(&mut self, mut id: NodeIdType) {
-        loop {
-            if let Some(node_state) = self.node_state_of_mut(&id) {
-                node_state.open = true;
-                id = match node_state.parent_id {
-                    Some(id) => id,
-                    None => break,
-                }
-            } else {
-                break;
+        while let Some(node_state) = self.node_state_of_mut(&id) {
+            node_state.open = true;
+            id = match node_state.parent_id {
+                Some(id) => id,
+                None => break,
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -192,7 +192,7 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
             self.selection_cursor = None;
         }
     }
-    
+
     pub(crate) fn handle_click(
         &mut self,
         clicked_id: NodeIdType,
@@ -230,7 +230,13 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
         }
     }
 
-    pub(crate) fn handle_key(&mut self, key: &Key, modifiers: &Modifiers, allow_multi_select: bool, opened: &mut Option<Modifiers>) {
+    pub(crate) fn handle_key(
+        &mut self,
+        key: &Key,
+        modifiers: &Modifiers,
+        allow_multi_select: bool,
+        opened: &mut Option<Modifiers>,
+    ) {
         match key {
             Key::ArrowUp | Key::ArrowDown => 'arm: {
                 let Some(pivot_id) = self.selection_pivot else {
@@ -288,10 +294,11 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
                 }
             }
             Key::Enter => 'arm: {
-                let Some(_current_cursor_id) = self.selection_cursor.or(self.selection_pivot) else {
+                let Some(_current_cursor_id) = self.selection_cursor.or(self.selection_pivot)
+                else {
                     break 'arm;
                 };
-                opened.replace(modifiers.clone()); 
+                opened.replace(modifiers.clone());
             }
             Key::ArrowLeft => 'arm: {
                 if self.selected.len() != 1 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,6 +32,8 @@ pub(crate) struct NodeState<NodeIdType> {
     pub drop_allowed: bool,
     /// Wether this node is a directory.
     pub dir: bool,
+    /// Wether this node can be activated.
+    pub activatable: bool,
 }
 
 /// Represents the state of the tree view.

--- a/src/state.rs
+++ b/src/state.rs
@@ -235,7 +235,6 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
         key: &Key,
         modifiers: &Modifiers,
         allow_multi_select: bool,
-        opened: &mut Option<Modifiers>,
     ) {
         match key {
             Key::ArrowUp | Key::ArrowDown => 'arm: {
@@ -292,13 +291,6 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
                     self.selected.push(cursor_id);
                     self.selection_pivot = Some(cursor_id);
                 }
-            }
-            Key::Enter => 'arm: {
-                let Some(_current_cursor_id) = self.selection_cursor.or(self.selection_pivot)
-                else {
-                    break 'arm;
-                };
-                opened.replace(modifiers.clone());
             }
             Key::ArrowLeft => 'arm: {
                 if self.selected.len() != 1 {


### PR DESCRIPTION
This adds `opened` to the state API which allows apps to perform actions when double clicking the final selection node, or pressing enter.  works for multiple selections, also exposes the modifier keys.

https://github.com/user-attachments/assets/66830ff6-77d5-4c80-9b68-2182f4c74a24

This is handy for tree-views that show a directory structure, where double clicking or pressing enter can be used to open the selected files.

A working example `opened.rs` is included.

Additionally:
* renames `modifier` to `modifiers` in the `handle_key` method.
* fixes a typo in `current_curor_id` which should be `current_cursor_id`.