### PR TITLE
Implement Action::SetSelected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,10 +147,6 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
             )
         });
 
-        if !settings.allow_multi_select {
-            state.prune_selection_to_single_id();
-        }
-
         let (ui_data, tree_view_rect) = draw_foreground(
             ui,
             id,
@@ -159,6 +155,10 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
             build_tree_view,
             &mut fallback_context_menu,
         );
+
+        if !settings.allow_multi_select {
+            state.prune_selection_to_single_id();
+        }
         // Remember the size of the tree for next frame.
         //state.size = response.rect.size();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,6 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
         Output::SelectOneNode(id) => {
             ui_data.selected = true;
             state.set_one_selected(id.clone());
-            state.set_pivot(Some(id));
             state.set_cursor(None);
         }
         Output::ToggleSelection(id) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,8 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
                 }));
             }
         }
-        // Create a selection action.
-        // TODO:
-        if false {
+
+        if ui_data.selected {
             actions.push(Action::SetSelected(state.selected().clone()));
         }
 
@@ -406,6 +405,7 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
         drop_marker_idx: ui.painter().add(Shape::Noop),
         drop_target: None,
         activate: None,
+        selected: false,
         space_used: Rect::from_min_size(ui.cursor().min, Vec2::ZERO),
     };
     // Run the build tree view closure
@@ -457,15 +457,18 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
             ui_data.activate = Some(vec![id]);
         }
         Output::SelectOneNode(id) => {
+            ui_data.selected = true;
             state.set_one_selected(id.clone());
             state.set_pivot(Some(id));
             state.set_cursor(None);
         }
         Output::ToggleSelection(id) => {
+            ui_data.selected = true;
             state.toggle_selected(&id);
             state.set_pivot(Some(id));
         }
         Output::ShiftSelect(ids) => {
+            ui_data.selected = true;
             state.set_selected_dont_change_pivot(ids);
         }
         Output::Select {
@@ -473,6 +476,7 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
             pivot,
             cursor,
         } => {
+            ui_data.selected = true;
             state.set_selected(selection);
             state.set_pivot(Some(pivot));
             state.set_cursor(Some(cursor));
@@ -728,6 +732,7 @@ struct UiData<NodeIdType> {
     drop_marker_idx: ShapeIdx,
     drop_target: Option<(NodeIdType, DirPosition<NodeIdType>)>,
     activate: Option<Vec<NodeIdType>>,
+    selected: bool,
     space_used: Rect,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -114,8 +114,9 @@ impl<NodeIdType: NodeId> TreeViewState<NodeIdType> {
 
     pub(crate) fn prune_selection_to_single_id(&mut self) {
         if self.selected.len() > 1 {
-            let new_selection = self.selected[0].clone();
-            self.set_one_selected(new_selection);
+            if let Some(new_selection) = &self.selection_pivot {
+                self.set_one_selected(new_selection.clone());
+            }
         }
     }
     pub(crate) fn get_simplified_dragged(&self) -> Option<&Vec<NodeIdType>> {


### PR DESCRIPTION
Adds a flag for when selection is changed so that `Action::SetSelected` is populated.

Tested in my own code, and by changing

 https://github.com/LennysLounge/egui_ltreeview/blob/c76ee73a415d91b52109a0af80c368151b8c1cd1/examples/playground/main.rs#L190

to

```rust
            Action::SetSelected(nodes) => {
                println!("selection: {:?}", nodes);
            }
```