### PR TITLE
Allow tree to go smaller than previous min width

### DIFF
--- a/examples/tall_tree_varying_widths.rs
+++ b/examples/tall_tree_varying_widths.rs
@@ -1,0 +1,39 @@
+use egui::{ScrollArea, ThemePreference};
+use egui_ltreeview::TreeView;
+
+fn main() -> Result<(), eframe::Error> {
+    //env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([500.0, 500.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Egui_ltreeview tall tree with varying width nodes",
+        options,
+        Box::new(|cc| {
+            cc.egui_ctx
+                .options_mut(|options| options.theme_preference = ThemePreference::Dark);
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}
+
+#[derive(Default)]
+struct MyApp {}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("tree panel").show(ctx, |ui| {
+            ScrollArea::vertical().show(ui, |ui| {
+                TreeView::new(ui.make_persistent_id("Names tree view")).show(ui, |builder| {
+                    for val in 1..100 {
+                        let width = 1 + val / 5;
+                        let name = width.to_string().repeat(width);
+                        builder.leaf(val, name);
+                    }
+                });
+            });
+        });
+        egui::CentralPanel::default().show(ctx, |_ui| {});
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
 /// The width of the tree view is the largest of either:
 /// * the remaining width of the ui using [`ui.available_size().x`](https://docs.rs/egui/latest/egui/struct.Ui.html#method.available_size)
 /// * the minimum width via [`TreeViewSettings::min_width`] or [`TreeView::min_width`]
-/// * the largest width of any node in the tree[^1]
+/// * the largest width of any node in the tree
 ///
 /// The height of the tree view is the largest of either:
 /// * the remaining height of the ui using [`ui.available_size().y`](https://docs.rs/egui/latest/egui/struct.Ui.html#method.available_size)
@@ -361,10 +361,6 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
 ///         });
 /// });
 /// ```
-///
-/// [^1]: The tree view stores the width of the largest node it had to render in the [`TreeViewState`].
-/// The consequence of this is that the tree view might expand to a larget width than necessary
-/// even if all nodes in the tree are shorter.
 impl<NodeIdType: NodeId> TreeView<NodeIdType> {
     /// Set the minimum width the tree can have.
     pub fn min_width(mut self, width: f32) -> Self {
@@ -391,8 +387,7 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
     let interaction_rect = Rect::from_min_size(
         ui.cursor().min,
         ui.available_size()
-            .at_least(vec2(settings.min_width, settings.min_height))
-            .at_least(vec2(state.min_width, 0.0)),
+            .at_least(vec2(settings.min_width, settings.min_height)),
     );
 
     let interaction = interact_no_expansion(ui, interaction_rect, id, Sense::click_and_drag());
@@ -427,9 +422,6 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
 
     let tree_view_rect = ui_data.space_used.union(interaction_rect);
     ui.allocate_rect(tree_view_rect, Sense::hover());
-
-    // Remember width of the tree view for next frame
-    state.min_width = state.min_width.at_least(ui_data.space_used.width());
 
     // Do context menu
     if !ui_data.context_menu_was_open {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl<NodeIdType: NodeId> TreeView<NodeIdType> {
 /// The width of the tree view is the largest of either:
 /// * the remaining width of the ui using [`ui.available_size().x`](https://docs.rs/egui/latest/egui/struct.Ui.html#method.available_size)
 /// * the minimum width via [`TreeViewSettings::min_width`] or [`TreeView::min_width`]
-/// * the largest width of any node in the tree
+/// * the largest width of any (currently visible) node in the tree
 ///
 /// The height of the tree view is the largest of either:
 /// * the remaining height of the ui using [`ui.available_size().y`](https://docs.rs/egui/latest/egui/struct.Ui.html#method.available_size)

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,8 +26,6 @@ pub struct TreeViewState<NodeIdType: Eq + std::hash::Hash> {
     selection_cursor: Option<NodeIdType>,
     /// Id of the node that was right clicked.
     pub(crate) secondary_selection: Option<NodeIdType>,
-    /// The minimum width of the tree view.
-    pub(crate) min_width: f32,
     /// Open states of the dirs in this tree.
     node_states: HashMap<NodeIdType, bool>,
     /// Wether or not the context menu was open last frame.
@@ -46,7 +44,6 @@ impl<NodeIdType: NodeId> Default for TreeViewState<NodeIdType> {
             selection_cursor: None,
             dragged: Default::default(),
             secondary_selection: Default::default(),
-            min_width: 0.0,
             node_states: HashMap::new(),
             context_menu_was_open: false,
             last_clicked_node: None,


### PR DESCRIPTION
Removes the logic keeping the tree larger, I'm not sure how intentional this logic was, but I wanted to remove it, so I'm also opening it as a PR here.

The tree is still kept to the minimum size of the currently visible portion of the tree, it just doesn't store any previous max (which I don't think was really necessary anymore anyway).