### PR TITLE
 Don't persist min_width field

### DIFF
--- a/examples/tall_tree_varying_widths.rs
+++ b/examples/tall_tree_varying_widths.rs
@@ -1,0 +1,39 @@
+use egui::{ScrollArea, ThemePreference};
+use egui_ltreeview::TreeView;
+
+fn main() -> Result<(), eframe::Error> {
+    //env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([500.0, 500.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Egui_ltreeview tall tree with varying width nodes",
+        options,
+        Box::new(|cc| {
+            cc.egui_ctx
+                .options_mut(|options| options.theme_preference = ThemePreference::Dark);
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}
+
+#[derive(Default)]
+struct MyApp {}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("tree panel").show(ctx, |ui| {
+            ScrollArea::vertical().show(ui, |ui| {
+                TreeView::new(ui.make_persistent_id("Names tree view")).show(ui, |builder| {
+                    for val in 1..100 {
+                        let width = 1 + val / 5;
+                        let name = width.to_string().repeat(width);
+                        builder.leaf(val, name);
+                    }
+                });
+            });
+        });
+        egui::CentralPanel::default().show(ctx, |_ui| {});
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,7 @@ pub struct TreeViewState<NodeIdType: Eq + std::hash::Hash> {
     /// Id of the node that was right clicked.
     pub(crate) secondary_selection: Option<NodeIdType>,
     /// The minimum width of the tree view.
+    #[cfg_attr(feature = "persistence", serde(skip))]
     pub(crate) min_width: f32,
     /// The hight of the tree view last frame.
     pub(crate) last_height: f32,


### PR DESCRIPTION
Adds `tall_tree_varying_widths` example and removes persistence of the min_width field.

This is a replacement for #21, reopened to keep git history cleaner (this will close that PR).

Tested manually, since persistence isn't testable in examples (at least not with anything I could find).