### PR TITLE
Make WASM target build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+dist/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ egui = { version = "0.32" }
 serde = { version = "1", features = ["derive"], optional = true }
 make_table_of_contents = { path = "make_table_of_contents", version = "0.1.0", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1", features = ["v4", "js"] }
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+
+
 [dev-dependencies]
 eframe = "0.32"
 egui_extras = { version = "0.32", features = ["all_loaders"] }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ to the tree. The nodes of the tree must have a unqiue id which implements the [`
 The examples folder contains a few examples to get you up and running quickly.
 It also contains a [`playground`](https://github.com/LennysLounge/egui_ltreeview/blob/main/examples/playground/main.rs) example witch implements every feature of this widget and lets you change its settings on the fly. You can run it using `cargo run --example playground`.
 
+# WASM Example
+See the wasm_example folder.
+
+# WASM Example
+Install trunk: `cargo install --locked trunk` for serving the files
+Build and run the example with `trunk serve`
+
 # Demo
 ![Demo showing selection, moving and creation of files in the tree view](demo.gif)
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -115,9 +115,11 @@ impl<'ui, NodeIdType: NodeId> TreeViewBuilder<'ui, NodeIdType> {
     /// Close the current directory.
     pub fn close_dir(&mut self) {
         while let Some(dir_state) = self.stack.pop() {
-            let indent = self
-                .indents
-                .pop_if(|indent| indent.source_node == dir_state.id);
+            let indent = if self.indents.last().map(|indent| indent.source_node == dir_state.id).unwrap_or(false) {
+                self.indents.pop()
+            } else {
+                None
+            };
             if let Some(indent) = indent {
                 self.draw_indent_hint(&indent);
                 match self.ui_data.drop_target.as_ref() {

--- a/wasm_example/Cargo.toml
+++ b/wasm_example/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "egui_ltreeview_wasm_example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+egui_ltreeview = { path = ".." }
+egui = "0.32"
+eframe = "0.32"
+log = "0.4"
+uuid = { version = "1", features = ["v4", "js"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"

--- a/wasm_example/README.md
+++ b/wasm_example/README.md
@@ -1,0 +1,7 @@
+This example is in its own folder in order to be able to serve it whith trunk.
+
+### Install trunk
+`cargo install --locked trunk`
+
+### Build and run
+`trunk serve`

--- a/wasm_example/Trunk.toml
+++ b/wasm_example/Trunk.toml
@@ -1,0 +1,16 @@
+[build]
+target = "index.html"
+dist = "dist"
+public_url = "/"
+
+[serve]
+addresses = ["127.0.0.1"]
+port = 8081
+open = true
+
+[watch]
+watch = ["src"]
+ignore = ["dist"]
+
+[tools]
+wasm-bindgen = "0.2"

--- a/wasm_example/index.html
+++ b/wasm_example/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Egui LTreeView Simple Example</title>
+    <link data-trunk rel="rust" />
+    <style>
+        html {
+            height: 100%;
+        }
+        body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #222;
+            color: white;
+        }
+        canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+        #loading {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            font-size: 1.2em;
+        }
+    </style>
+</head>
+<body>
+    <div id="loading">Loading...</div>
+    <canvas id="the_canvas_id" style="display: none;"></canvas>
+    
+    <script type="module">
+        // Wait for Trunk to load the WASM module
+        window.addEventListener('TrunkApplicationStarted', async (event) => {
+            try {
+                // Hide loading and show canvas
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('the_canvas_id').style.display = 'block';
+                
+                // Start the eframe app using the bindings that Trunk provides
+                window.wasmBindings.start("the_canvas_id");
+            } catch (error) {
+                console.error("Failed to start app:", error);
+                document.getElementById('loading').textContent = "Failed to load app: " + error;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/wasm_example/src/data.rs
+++ b/wasm_example/src/data.rs
@@ -1,0 +1,90 @@
+#![allow(unused)]
+
+use std::any::Any;
+
+use uuid::Uuid;
+
+fn main() {}
+
+pub enum Node {
+    Directory(Directory),
+    File(File),
+}
+pub struct Directory {
+    pub id: Uuid,
+    pub name: String,
+    pub children: Vec<Node>,
+}
+pub struct File {
+    pub id: Uuid,
+    pub name: String,
+}
+
+impl Node {
+    pub fn dir(name: &'static str, children: Vec<Node>) -> Self {
+        Node::Directory(Directory {
+            id: Uuid::new_v4(),
+            name: String::from(name),
+            children,
+        })
+    }
+    pub fn file(name: &'static str) -> Self {
+        Node::File(File {
+            id: Uuid::new_v4(),
+            name: String::from(name),
+        })
+    }
+
+    pub fn id(&self) -> &Uuid {
+        match self {
+            Node::Directory(dir) => &dir.id,
+            Node::File(file) => &file.id,
+        }
+    }
+
+    pub fn find(&self, id: &Uuid, action: &mut dyn FnMut(&Node)) {
+        if self.id() == id {
+            (action)(self);
+        } else {
+            match self {
+                Node::Directory(dir) => {
+                    for node in dir.children.iter() {
+                        node.find(id, action);
+                    }
+                }
+                Node::File(_) => (),
+            }
+        }
+    }
+    pub fn find_mut(&mut self, id: &Uuid, action: &mut dyn FnMut(&mut Node)) {
+        if self.id() == id {
+            (action)(self);
+        } else {
+            match self {
+                Node::Directory(dir) => {
+                    for node in dir.children.iter_mut() {
+                        node.find_mut(id, action);
+                    }
+                }
+                Node::File(_) => (),
+            }
+        }
+    }
+}
+pub fn make_tree() -> Node {
+    Node::dir(
+        "Root",
+        vec![
+            Node::dir(
+                "Foo",
+                vec![
+                    Node::file("Ava"),
+                    Node::dir("bar", vec![Node::file("Benjamin"), Node::file("Charlotte")]),
+                ],
+            ),
+            Node::file("Daniel"),
+            Node::file("Emma"),
+            Node::dir("bar", vec![Node::file("Finn"), Node::file("Grayson")]),
+        ],
+    )
+}

--- a/wasm_example/src/lib.rs
+++ b/wasm_example/src/lib.rs
@@ -1,0 +1,90 @@
+#[path = "data.rs"]
+mod data;
+
+use egui::ThemePreference;
+use egui_ltreeview::TreeView;
+
+
+#[derive(Default)]
+struct MyApp {}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            TreeView::new(ui.make_persistent_id("Names tree view")).show(ui, |builder| {
+                builder.dir(0, "Root");
+                builder.dir(1, "Foo");
+                builder.leaf(2, "Ava");
+                builder.dir(3, "Bar");
+                builder.leaf(4, "Benjamin");
+                builder.leaf(5, "Charlotte");
+                builder.close_dir();
+                builder.close_dir();
+                builder.leaf(6, "Daniel");
+                builder.leaf(7, "Emma");
+                builder.dir(8, "Baz");
+                builder.leaf(9, "Finn");
+                builder.leaf(10, "Grayson");
+                builder.close_dir();
+                builder.close_dir();
+            });
+        });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+use eframe::wasm_bindgen::{self, prelude::*};
+
+#[cfg(target_arch = "wasm32")]
+use web_sys::HtmlCanvasElement;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn start(canvas_id: &str) -> Result<(), wasm_bindgen::JsValue> {
+    eframe::WebLogger::init(log::LevelFilter::Debug).ok();
+    
+    let web_options = eframe::WebOptions::default();
+    
+    // Get the canvas element from DOM
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let canvas = document
+        .get_element_by_id(canvas_id)
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+    
+    wasm_bindgen_futures::spawn_local(async move {
+        eframe::WebRunner::new()
+            .start(
+                canvas,
+                web_options,
+                Box::new(|cc| {
+                    cc.egui_ctx
+                        .options_mut(|options| options.theme_preference = ThemePreference::Dark);
+                    Ok(Box::<MyApp>::default())
+                }),
+            )
+            .await
+            .expect("failed to start eframe");
+    });
+    
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() -> Result<(), eframe::Error> {
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([300.0, 500.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Egui_ltreeview simple example",
+        options,
+        Box::new(|cc| {
+            cc.egui_ctx
+                .options_mut(|options| options.theme_preference = ThemePreference::Dark);
+            Ok(Box::<MyApp>::default())
+        }),
+    )
+}


### PR DESCRIPTION
Added `"js"` feature to `uuid` when compiling for WASM.
Added `wasm_example` as I could not get `trunk serve` to work when the example code was added as am example.
Added instruction to how to serve the `wasm_example `with `trunk serve`