### PR TITLE
Do not change the openness when double-clicking if a node is activatable

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -724,14 +724,15 @@ impl<'ui, NodeIdType: NodeId> TreeViewBuilder<'ui, NodeIdType> {
                 shift_click_nodes,
             } => 'block: {
                 // Closer click
-                if closer.is_some_and(|closer| rect_contains_visually(closer, pos)) {
+                let closer_clicked = closer.is_some_and(|closer| rect_contains_visually(closer, pos));
+                if closer_clicked {
                     self.state.set_openness(node.id.clone(), !node.is_open);
                     *self.input = Input::None;
                     break 'block;
                 }
 
                 let row_clicked = rect_contains_visually(row_rect, pos);
-                let double_click = row_clicked && *double && self.state.was_clicked_last(&node.id);
+                let double_click = row_clicked && *double && !closer_clicked && self.state.was_clicked_last(&node.id);
                 if row_clicked {
                     self.state.set_last_clicked(&node.id);
                 }
@@ -743,13 +744,14 @@ impl<'ui, NodeIdType: NodeId> TreeViewBuilder<'ui, NodeIdType> {
 
                 // Double clicked
                 if double_click {
-                    self.state.set_openness(node.id.clone(), !node.is_open);
                     if node.activatable {
                         if self.state.is_selected(&node.id) {
                             *self.output = Output::ActivateSelection(activatable_nodes.clone());
                         } else {
                             *self.output = Output::ActivateThis(node.id.clone());
                         }
+                    } else {
+                        self.state.set_openness(node.id.clone(), !node.is_open);
                     }
                     *self.input = Input::None;
                     break 'block;

--- a/src/doc/doc.md
+++ b/src/doc/doc.md
@@ -45,6 +45,12 @@ Either `Double Clicking` or the `Enter` key will activate the current selection.
 
 A usual use case for activating nodes is opening a node in a new window. For example a file viewer might open the contents of a file in a new tab when activated.
 
+## Opening closing directory nodes
+
+A directory node can be usally opened/closed in three ways, a) by clicking on the 'closer' icon for it. b) double clicking elsewhere on the row, c) using the keyboard, as above.
+
+However, to avoid user intention confusion for activatable directory nodes when a directory node is 'activatable', double-clicking will only 'activate' the node, and will not expand or collapse the directory.
+
 ## Drag and drop
 If drag and drop is enabled in the [`TreeViewSettings::allow_drag_and_drop`], the tree view has support for implementing drag and drop in your data structure.
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -64,6 +64,8 @@ pub trait NodeConfig<NodeIdType> {
     /// Whether or not this node can be activated.
     ///
     /// Default is false for directories and true otherwise. Override to customize.
+    /// Enabling 'activatable' disables double-click to expand/collapse for directories, directories can still be
+    /// expanded/collapsed using the 'opener' icon or the keyboard.
     fn activatable(&self) -> bool {
         !self.is_dir()
     }


### PR DESCRIPTION
It's all about user intent.  What is the intention of the user when they double click an activatable directory node? do they want to open it or do they want to activate it?  with the current behavior it does both.

This PR changes it so that when double-clicking on a directory node that is activatable the openness is not changed.  If a directory node is not activatable, then the openness _is_ changed.

Activatable nodes can still be opened/closed when clicking the closer directly.

Video:
https://github.com/user-attachments/assets/a7493268-7635-46ea-a573-9934845a18d0

Background: In my MakerPnP planner app, I need to open tabs when double clicking on directory nodes, but currently when I double click on them to activate them the directory changes, which is frustrating.  This PR fixes it, as follows:

The MakerPnP planner app BEFORE this PR.

https://github.com/user-attachments/assets/4ad3caf5-c5eb-4a2a-8815-25b2597d528c

And with this PR:

https://github.com/user-attachments/assets/149918fb-a898-4bfb-9588-f753936a781f

Way much better user experience (UX).