### PR TITLE
Fix tree view taking up more space than necessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ fn draw_foreground<'context_menu, NodeIdType: NodeId>(
     );
     build_tree_view(&mut tree_builder);
 
-    let tree_view_rect = ui_data.space_used.union(interaction_rect);
+    let tree_view_rect = ui_data.space_used.intersect(interaction_rect);
     ui.allocate_rect(tree_view_rect, Sense::hover());
 
     // Remember width of the tree view for next frame


### PR DESCRIPTION
Hello, thanks for the nice widget, it is really pleasant to use and looks great!

I have noticed, that the widget seems to take up all remaining vertical space, even if the nodes dont actually require it.
To fix this, I intersected the interaction rectangle with the used space instead of taking the union.

In my own tests, this works great, but I'm no egui layout wizard, so I am not sure if this could break anything.